### PR TITLE
use stylelint-order

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -1,10 +1,10 @@
 module.exports = function (order) {
-  const config = []
+  let config = []
 
   for (let property in order) {
     if (order.hasOwnProperty(property)) {
       for (let i = 0; i < order[property].length; i++) {
-        config.push({ "properties": order[property][i] })
+        config = config.concat(order[property][i])
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,10 @@ const generate = require("./generate")
 const config = generate(order)
 
 module.exports = {
+  "plugins": [
+    "stylelint-order",
+  ],
   "rules": {
-    "declaration-block-properties-order": config,
+    "order/declaration-block-properties-specified-order": config,
   },
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,10 @@
   "devDependencies": {
     "eslint": "^3.10.0",
     "eslint-config-stylelint": "^5.0.0",
-    "stylelint": "^7.9.0",
+    "stylelint": "^7.8.0",
     "tape": "^4.6.3"
+  },
+  "peerDependencies": {
+    "stylelint": "^7.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,11 +26,13 @@
   },
   "homepage": "https://github.com/cahamilton/stylelint-config-property-sort-order-smacss#readme",
   "dependencies": {
-    "css-property-sort-order-smacss": "^1.1.0"
+    "css-property-sort-order-smacss": "^1.1.0",
+    "stylelint-order": "^0.3.0"
   },
   "devDependencies": {
     "eslint": "^3.10.0",
     "eslint-config-stylelint": "^5.0.0",
+    "stylelint": "^7.9.0",
     "tape": "^4.6.3"
   }
 }

--- a/tests/expected.js
+++ b/tests/expected.js
@@ -1,36 +1,12 @@
 module.exports = [
-  {
-    "properties": [
-      "prop1",
-      "prop2",
-    ],
-  },
-  {
-    "properties": [
-      "prop3",
-    ],
-  },
-  {
-    "properties": [
-      "prop4",
-    ],
-  },
-  {
-    "properties": [
-      "prop5",
-      "prop6",
-    ],
-  },
-  {
-    "properties": [
-      "prop7",
-    ],
-  },
-  {
-    "properties": [
-      "prop8",
-      "prop9",
-      "prop10",
-    ],
-  },
+  "prop1",
+  "prop2",
+  "prop3",
+  "prop4",
+  "prop5",
+  "prop6",
+  "prop7",
+  "prop8",
+  "prop9",
+  "prop10",
 ]

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,4 +1,6 @@
 const test = require("tape")
+const stylelint = require("stylelint")
+const stylelintConfig = require("..")
 const order = require("./sort-order")
 const expected = require("./expected")
 
@@ -8,4 +10,18 @@ test("Generate configuration", function (t) {
   const actual = generate(order)
   t.deepEqual(actual, expected)
   t.end()
+})
+
+test("Stylelint configuration", function (t) {
+  stylelint.lint({
+    code: "a { color: red; top: 0; }",
+    config: stylelintConfig,
+  }).then(function (output) {
+    const actual = output.results[0].warnings[0].text
+    t.equal(actual, "Expected top to come before color (order/declaration-block-properties-specified-order)")
+    t.end()
+  }).catch(function (err) {
+    t.notOk(err)
+    t.end()
+  })
 })


### PR DESCRIPTION
migration from the deprecation of `declaration-block-properties-order` to using `stylelint-order`

I wasn't too sure how to handle the dependancy for `stylelint-order`. It could be a `peerDependancy`, along with `stylelint`. But the config depends directly on the `stylelint-order` plugin, so it probably should be a dependency