### PR TITLE
Upgrade to stylelint 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
   "homepage": "https://github.com/cahamilton/stylelint-config-property-sort-order-smacss#readme",
   "dependencies": {
     "css-property-sort-order-smacss": "^1.1.0",
-    "stylelint-order": "^0.4.4"
+    "stylelint-order": "^0.6.0"
   },
   "devDependencies": {
     "eslint": "^3.19.0",
     "eslint-config-stylelint": "^6.0.0",
-    "stylelint": "^7.10.1",
+    "stylelint": "^8.0.0",
     "tape": "^4.6.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
I upgraded `stylelint-order` because the release notes mention `0.6.0` supporting `stylelint 8.0`.