### PR TITLE
Clear alphabetical sort order when using smacss

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,5 +11,6 @@ module.exports = {
   ],
   "rules": {
     "order/properties-order": config,
+    "order/properties-alphabetical-order": null,
   },
 }


### PR DESCRIPTION
Other property sort orders, such as the default, alphabetical conflict with smacss sort order.

This makes it impossible to clear all errors.

e.g. 
```scss
.a {
  z-index: 99;
  top: 0;
}
```
Is ordered correctly for SMACSS but not for alphabetical.