### PR TITLE
Update peerDependencies to support stylelint@^13.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 
 env:
   matrix:
+    - "STYLELINT=13"
     - "STYLELINT=12"
     - "STYLELINT=11"
     - "STYLELINT=10"

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
   "devDependencies": {
     "eslint": "^6.6.0",
     "eslint-config-stylelint": "^11.0.0",
-    "stylelint": "^10.0.0 || ^11.0.0 || ^12.0.0",
+    "stylelint": "^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
     "tape": "^4.10.1"
   },
   "peerDependencies": {
-    "stylelint": "^10.0.0 || ^11.0.0 || ^12.0.0"
+    "stylelint": "^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0"
   }
 }


### PR DESCRIPTION
Just extended the diffs from this PR: https://github.com/cahamilton/stylelint-config-property-sort-order-smacss/pull/24