### PR TITLE
Add Stylelint v16 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14, 16, 18]
-        stylelint: [14, 15]
+        node-version: [18, 20]
+        stylelint: [14, 15, 16]
 
     steps:
     - name: Checkout
@@ -52,7 +52,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
 
     - name: Install dependencies
       run: npm install

--- a/README.md
+++ b/README.md
@@ -73,17 +73,17 @@ a {
 
 Refer to [css-property-sort-order-smacss](https://github.com/cahamilton/css-property-sort-order-smacss/blob/v2.2.0/index.js) for the comprehensive list of property orders.
 
-For more information on configuring Stylelint, check out the [configuration](https://github.com/stylelint/stylelint/blob/15.0.0/docs/user-guide/configure.md) guide.
+For more information on configuring Stylelint, check out the [configuration](https://github.com/stylelint/stylelint/blob/16.0.0/docs/user-guide/configure.md) guide.
 
 ## Advanced
 
 **This is currently only possible with an exported JavaScript configuration.**
 
-The basic usage outlined above, will enforce that properties are **strictly** sorted within their groups (box, border, background etc). Given this configuration makes use of [stylelint-order](https://github.com/hudochenkov/stylelint-order/tree/5.0.0) under the hood, there's a couple extra bits of functionality that can be configured. This will require manually generating the configuration - but passing in extra options as seen fit. These will be applied to **each** property group.
+The basic usage outlined above, will enforce that properties are **strictly** sorted within their groups (box, border, background etc). Given this configuration makes use of [stylelint-order](https://github.com/hudochenkov/stylelint-order/tree/6.0.4) under the hood, there's a couple extra bits of functionality that can be configured. This will require manually generating the configuration - but passing in extra options as seen fit. These will be applied to **each** property group.
 
 ### Options
 
-Refer to the [properties-order](https://github.com/hudochenkov/stylelint-order/blob/5.0.0/rules/properties-order/README.md#options) documentation for a list of available options.
+Refer to the [properties-order](https://github.com/hudochenkov/stylelint-order/blob/6.0.4/rules/properties-order/README.md#options) documentation for a list of available options.
 
 All options except `properties` and `groupName` can be modified.
 

--- a/__tests__/generate.test.js
+++ b/__tests__/generate.test.js
@@ -1,12 +1,14 @@
 /** @format */
 
-const generate = require('../generate');
+const proxyquire = require('proxyquire');
 
-jest.mock('css-property-sort-order-smacss', () => ({
-  groupA: [['prop1', 'prop2'], ['prop3']],
-  groupB: ['prop4', 'prop5', 'prop6', 'prop7'],
-  groupC: [['prop8', 'prop9', 'prop10']],
-}));
+const generate = proxyquire.noCallThru().load('../generate', {
+  'css-property-sort-order-smacss': {
+    groupA: [['prop1', 'prop2'], ['prop3']],
+    groupB: ['prop4', 'prop5', 'prop6', 'prop7'],
+    groupC: [['prop8', 'prop9', 'prop10']],
+  },
+});
 
 describe('generate options', () => {
   it('should correctly group properties', () => {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -11,7 +11,11 @@ const index = require('../index');
  * @return {Promise<{errored, invalidOptionWarnings, warnings}>}
  */
 const lintCode = async ({ code, config }) => {
-  const actual = await stylelint.lint({ code, config });
+  const actual = await stylelint.lint({
+    code,
+    config,
+    quietDeprecationWarnings: true,
+  });
 
   const { errored, results } = actual;
   const { invalidOptionWarnings, warnings } = results[0];

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 /** @format */
 
 module.exports = {
+  runner: 'jest-light-runner',
   cacheDirectory: '/tmp/jest/',
   collectCoverage: true,
   coverageDirectory: 'coverage',

--- a/package.json
+++ b/package.json
@@ -7,10 +7,13 @@
     "index.js",
     "generate.js"
   ],
+  "engines": {
+    "node": ">=18.12.0"
+  },
   "scripts": {
     "coverage": "coveralls < coverage/lcov.info",
     "eslint": "eslint .",
-    "jest": "jest",
+    "jest": "NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" jest",
     "prettier": "prettier --check '**/*.js'",
     "test": "npm run eslint && npm run prettier && npm run jest"
   },
@@ -35,7 +38,7 @@
   "homepage": "https://github.com/cahamilton/stylelint-config-property-sort-order-smacss#readme",
   "dependencies": {
     "css-property-sort-order-smacss": "~2.2.0",
-    "stylelint-order": "^6.0.2"
+    "stylelint-order": "^6.0.4"
   },
   "devDependencies": {
     "coveralls": "^3.1.0",
@@ -44,10 +47,12 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "^2.25.2",
     "jest": "^29.0.1",
+    "jest-light-runner": "^0.6.0",
     "prettier": "^3.0.0",
-    "stylelint": "^14.0.0 || ^15.0.0"
+    "proxyquire": "^2.0.0",
+    "stylelint": "^14.0.0 || ^15.0.0 || ^16.0.0"
   },
   "peerDependencies": {
-    "stylelint": "^14.0.0 || ^15.0.0"
+    "stylelint": "^14.0.0 || ^15.0.0 || ^16.0.0"
   }
 }


### PR DESCRIPTION
Resolves #92

* Remove Node v14 and v16 support (EOL)
* Set minimum Node version required for Stylelint v16 in engines field
* Silence CJS deprecation warnings
* Fix segmentation fault with test runner